### PR TITLE
refact: refactor for v1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,20 @@ The Mandarine CLI allows you to create Mandarine-powered application in seconds 
 ### Installing
 
 In order to install the latest version of Mandarine's CLI, you need to have installed Deno in your computer. Then, run from your terminal the following command:
-`deno install -f --allow-read --allow-write --allow-run -n mandarine https://deno.land/x/mandarinets/cli.ts`
+
+```sh
+deno install -f --allow-read --allow-write --allow-run -n mandarine https://deno.land/x/mandarinets/cli.ts`
+```
+
+or use [Trex](https://github.com/crewdevio/Trex) package manager.
+
+```sh
+trex getTool mandarineCli
+```
 
 # Usage
 
-Please [click here](https://mandarineframework.gitbook.io/mandarine-ts/mandarine-cli/cli) for documentation.
+Please [click here](https://www.mandarinets.org/docs/master/mandarine/cli-introduction) for documentation.
 
 # Want to help?
 

--- a/commands/commandFactory.ts
+++ b/commands/commandFactory.ts
@@ -1,3 +1,5 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
 import { CommandMetadata, OptionsMetadata } from "../types/types.ts";
 
 export class CommandFactory {

--- a/commands/commands.ts
+++ b/commands/commands.ts
@@ -1,4 +1,6 @@
-import { green, yellow } from "https://deno.land/std/fmt/colors.ts"
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
+import { green, yellow } from "https://deno.land/std/fmt/colors.ts";
 import { GenerateCmd } from "../handlers/generateCmd.ts";
 import { CommandFactory } from "./commandFactory.ts";
 import { CommandMetadata } from "../types/types.ts";
@@ -151,12 +153,13 @@ export class Commands {
   }
 
   public getHelp() {
-
     const helpInfo = [
       green(`Mandarine CLI ${yellow(cliVersion)}\n`),
 
-      `\n${green('Docs:')} https://mandarineframework.gitbook.io/mandarine-ts/\n`,
-      `${green('Bugs:')} https://github.com/mandarineorg/mandarinets/issues\n`,
+      `\n${green(
+        "Docs:"
+      )} https://www.mandarinets.org/docs/mandarine/introduction\n`,
+      `${green("Bugs:")} https://github.com/mandarineorg/mandarinets/issues\n`,
 
       green("\nUSAGE:\n"),
       "   mandarine [OPTIONS] [SUBCOMAND]\n",
@@ -174,9 +177,7 @@ export class Commands {
     console.log(helpInfo);
 
     for (const { alias, command, description } of this.commands) {
-      console.log(
-        `${yellow(command)} (${alias})    ${description}.`
-      );
+      console.log(`${yellow(command)} (${alias})    ${description}.`);
     }
     console.log("\n");
   }

--- a/defaults/defaultFiles.ts
+++ b/defaults/defaultFiles.ts
@@ -1,69 +1,73 @@
-export const controllerFile = `import { Controller } from "https://deno.land/x/mandarinets/mod.ts";
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
 
-@Controller()
-export class %controllerName% {
-}
-`;
+export const enum defaultFiles {
+  controller = `import { Controller } from "https://deno.land/x/mandarinets/mod.ts";
 
-export const serviceFile = `import { Service } from "https://deno.land/x/mandarinets/mod.ts";
-
-@Service()
-export class %serviceName% {
-}
-`;
-
-export const componentFile = `import { Component } from "https://deno.land/x/mandarinets/mod.ts";
-
-@Component()
-export class %componentName% {
-}
-`;
-
-export const middlewareFile = `import { Middleware, MiddlewareTarget, ResponseParam, RequestParam } from "https://deno.land/x/mandarinets/mod.ts";
-
-@Middleware(new RegExp('/'))
-export class %middlewareName% implements MiddlewareTarget {
-
-    public onPreRequest(@RequestParam() request: any, @ResponseParam() response: any): boolean {
-        /**
-         * True = the request must continue,
-         * False = the request will stop
-         */
-        return true;
+    @Controller()
+    export class %controllerName% {
     }
+    `,
 
-    public onPostRequest(): void {
+  service = `import { Service } from "https://deno.land/x/mandarinets/mod.ts";
+
+    @Service()
+    export class %serviceName% {
     }
+    `,
 
-}
-`;
+  component = `import { Component } from "https://deno.land/x/mandarinets/mod.ts";
 
-export const repositoryFile = `import { Repository, MandarineRepository } from "https://deno.land/x/mandarinets/mod.ts";
-
-@Repository()
-export abstract class %repositoryName% extends MandarineRepository<YourModel> {
-
-    constructor() {
-        super(YourModel);
+    @Component()
+    export class %componentName% {
     }
+    `,
 
-}
-`;
+  middleware = `import { Middleware, MiddlewareTarget, ResponseParam, RequestParam } from "https://deno.land/x/mandarinets/mod.ts";
 
-export const configurationFile = `import { Configuration } from "https://deno.land/x/mandarinets/mod.ts";
+    @Middleware(new RegExp('/'))
+    export class %middlewareName% implements MiddlewareTarget {
 
-@Configuration()
-export class %configurationName% {
-}
-`;
+        public onPreRequest(@RequestParam() request: any, @ResponseParam() response: any): boolean {
+            /**
+             * True = the request must continue,
+             * False = the request will stop
+             */
+            return true;
+        }
 
-export const modelFile = `import { Table, Id, GeneratedValue, Column } from "https://deno.land/x/mandarinets/mod.ts";
+        public onPostRequest(): void {
+        }
 
-@Table({ schema: "public", name: "%modelTableName%" })
-export class %modelName% {
+    }
+    `,
+
+  repository = `import { Repository, MandarineRepository } from "https://deno.land/x/mandarinets/mod.ts";
+
+    @Repository()
+    export abstract class %repositoryName% extends MandarineRepository<YourModel> {
+
+        constructor() {
+            super(YourModel);
+        }
+
+    }
+    `,
+
+  configuration = `import { Configuration } from "https://deno.land/x/mandarinets/mod.ts";
+
+    @Configuration()
+    export class %configurationName% {
+    }
+`,
+
+  model = `import { Table, Id, GeneratedValue, Column } from "https://deno.land/x/mandarinets/mod.ts";
+
+    @Table({ schema: "public", name: "%modelTableName%" })
+    export class %modelName% {
 
     @Id()
     @GeneratedValue({strategy: "SEQUENCE"})
     @Column()
     public id: number;
-}`;
+}`,
+}

--- a/deps.ts
+++ b/deps.ts
@@ -1,3 +1,5 @@
-export { structure as MandarineProjectStructure } from "https://deno.land/x/mandarinets/mandarine-project-structure.ts";
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
+export { structure as MandarineProjectStructure } from "./utils/structure.ts";
 
 export { red, yellow, green, bold } from "https://deno.land/std/fmt/colors.ts";

--- a/handlers/generateCmd.ts
+++ b/handlers/generateCmd.ts
@@ -1,12 +1,6 @@
-import {
-  controllerFile,
-  serviceFile,
-  componentFile,
-  middlewareFile,
-  repositoryFile,
-  modelFile,
-  configurationFile,
-} from "../defaults/defaultFiles.ts";
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
+import { defaultFiles } from "../defaults/defaultFiles.ts";
 import { bold, green } from "../deps.ts";
 import { CommandMetadata, objectGen } from "../types/types.ts";
 import { CommandUtils } from "../utils/commandUtils.ts";
@@ -57,8 +51,8 @@ export const GenerateCmd = (
     return;
   }
 
-  let moduleFolder = `/src/main/mandarine/${moduleName}`;
-  let toGenerate: { folders: string[], files: objectGen } = {
+  let moduleFolder = `/src/mandarine/${moduleName}`;
+  let toGenerate: { folders: string[]; files: objectGen } = {
     folders: [moduleFolder],
     files: {},
   };
@@ -73,25 +67,23 @@ export const GenerateCmd = (
         componentName = `${moduleName}Controller`;
         toGenerate.files[
           `${moduleName}.controller.ts`
-        ] = controllerFile.replace("%controllerName%", componentName);
+        ] = defaultFiles.controller.replace("%controllerName%", componentName);
         break;
 
       case "service":
 
       case "s":
         componentName = `${moduleName}Service`;
-        toGenerate.files[`${moduleName}.service.ts`] = serviceFile.replace(
-          "%serviceName%",
-          componentName
-        );
+        toGenerate.files[
+          `${moduleName}.service.ts`
+        ] = defaultFiles.service.replace("%serviceName%", componentName);
         break;
 
       case "component":
         componentName = `${moduleName}Component`;
-        toGenerate.files[`${moduleName}.component.ts`] = componentFile.replace(
-          "%componentName%",
-          componentName
-        );
+        toGenerate.files[
+          `${moduleName}.component.ts`
+        ] = defaultFiles.component.replace("%componentName%", componentName);
         break;
       case "middleware":
 
@@ -99,7 +91,7 @@ export const GenerateCmd = (
         componentName = `${moduleName}Middleware`;
         toGenerate.files[
           `${moduleName}.middleware.ts`
-        ] = middlewareFile.replace("%middlewareName%", componentName);
+        ] = defaultFiles.middleware.replace("%middlewareName%", componentName);
         break;
       case "repository":
 
@@ -107,12 +99,12 @@ export const GenerateCmd = (
         componentName = `${moduleName}Repository`;
         toGenerate.files[
           `${moduleName}.repository.ts`
-        ] = repositoryFile.replace("%repositoryName%", componentName);
+        ] = defaultFiles.repository.replace("%repositoryName%", componentName);
         break;
 
       case "model":
         componentName = `${moduleName}Model`;
-        toGenerate.files[`${moduleName}.model.ts`] = modelFile
+        toGenerate.files[`${moduleName}.model.ts`] = defaultFiles.model
           .replace("%modelName%", componentName)
           .replace("%modelTableName%", moduleName);
         break;
@@ -121,7 +113,10 @@ export const GenerateCmd = (
         componentName = `${moduleName}Configuration`;
         toGenerate.files[
           `${moduleName}.configuration.ts`
-        ] = configurationFile.replace("%configurationName%", componentName);
+        ] = defaultFiles.configuration.replace(
+          "%configurationName%",
+          componentName
+        );
         break;
     }
   });

--- a/handlers/newCmd.ts
+++ b/handlers/newCmd.ts
@@ -1,3 +1,5 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
 import { CommandMetadata, objectGen } from "../types/types.ts";
 import { CommandUtils } from "../utils/commandUtils.ts";
 import { MandarineProjectStructure } from "../deps.ts";
@@ -9,18 +11,15 @@ export const NewCmd = (
   command: objectGen,
   options: objectGen
 ) => {
-
   CommandUtils.verifyRequiredOptions(cmd, options);
 
   CommandUtils.verifyValidityOptions(cmd, options);
   let cwd = Deno.cwd();
   let force = false;
 
-
   if (options["directory"]) cwd = options["directory"];
 
   if (options["d"]) cwd = options["d"];
-
 
   if (options["force"] || options["f"]) force = true;
 

--- a/handlers/runCmd.ts
+++ b/handlers/runCmd.ts
@@ -1,7 +1,8 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
 import { CommandMetadata, objectGen } from "../types/types.ts";
 import { CommandUtils } from "../utils/commandUtils.ts";
 import { red } from "../deps.ts";
-
 
 export const RunCmd = async (
   cmd: CommandMetadata,
@@ -11,7 +12,7 @@ export const RunCmd = async (
   CommandUtils.verifyRequiredOptions(cmd, options);
   CommandUtils.verifyValidityOptions(cmd, options);
 
-  let appFile = `${Deno.cwd()}/src/main/mandarine/app.ts`;
+  let appFile = `${Deno.cwd()}/src/mandarine/app.ts`;
   let tsConfig = `${Deno.cwd()}/tsconfig.json`;
 
   let entryPointOption = options["entry-point"];
@@ -62,7 +63,14 @@ export const RunCmd = async (
     denoRunOptions.allowAll = true;
   }
 
-  let denoCmd: string[] = ["deno", "run", "--config", tsConfig, "--allow-net"];
+  let denoCmd: string[] = [
+    "deno",
+    "run",
+    "--config",
+    tsConfig,
+    "--allow-net",
+    "--allow-env",
+  ];
 
   if (denoRunOptions.allowRead) denoCmd.push("--allow-read");
   if (denoRunOptions.allowWrite) denoCmd.push("--allow-write");

--- a/mod.ts
+++ b/mod.ts
@@ -1,7 +1,9 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
 import { parse } from "https://deno.land/std/flags/mod.ts";
 import { bold } from "https://deno.land/std/fmt/colors.ts";
 import { Commands } from "./commands/commands.ts";
-import { objectGen } from "./types/types.ts"
+import { objectGen } from "./types/types.ts";
 
 export async function Process(): Promise<void> {
   const { args } = Deno;
@@ -44,7 +46,6 @@ export async function Process(): Promise<void> {
   }
 
   if (!found) {
-
     console.log(`Found argument ${bold(
       (currentCommandName != undefined
         ? currentCommandName

--- a/types/types.ts
+++ b/types/types.ts
@@ -1,3 +1,5 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
 /**
  * object generic similar to use object but without errors
  * @type object generic

--- a/utils/commandUtils.ts
+++ b/utils/commandUtils.ts
@@ -1,3 +1,5 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
 import { CommandMetadata } from "../types/types.ts";
 import { bold } from "../deps.ts";
 

--- a/utils/commonUtils.ts
+++ b/utils/commonUtils.ts
@@ -1,3 +1,5 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
 export class CommonUtils {
   public static fileDirExists(path: string): boolean {
     try {

--- a/utils/structure.ts
+++ b/utils/structure.ts
@@ -1,0 +1,74 @@
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
+const enum Structure {
+  DefaultConfig = `{
+    "mandarine": {
+      "server": {
+        "host": "127.0.0.1",
+        "port": 8080,
+        "responseType": "text/html"
+      },
+      "resources": {
+        "staticFolder": "/src/resources/static",
+        "staticRegExpPattern": "/(.*)"
+      },
+      "templateEngine": {
+        "path": "./src/resources/templates",
+        "engine": "ejs"
+      }
+    }
+  }`,
+
+  DefaultHelloWorldEndpoint = `import { MandarineCore, Controller, GET } from "https://deno.land/x/mandarinets/mod.ts";
+@Controller()
+export class MyController {
+  @GET('/')
+  public httpHandler() {
+      return "Hello world";
+  }
+}
+`,
+  DefaultAppFile = `import { MandarineCore } from "https://deno.land/x/mandarinets/mod.ts";
+import { MyController } from "./hello_world/helloWorld.ts";
+const controllers = [MyController];
+const services = [];
+const middleware = [];
+const repositories = [];
+const configurations = [];
+const components = [];
+const otherModules = [];
+new MandarineCore().MVC().run();
+`,
+  DefaultTsConfig = `{
+    "compilerOptions": {
+      "strict": false,
+      "noImplicitAny": false,
+      "noImplicitThis": false,
+      "alwaysStrict": false,
+      "strictNullChecks": false,
+      "strictFunctionTypes": true,
+      "strictPropertyInitialization": false,
+      "experimentalDecorators": true,
+      "emitDecoratorMetadata": true
+    }
+  }`,
+}
+
+export const structure = {
+  folders: [
+    "/test",
+    "/src",
+    "/src/mandarine",
+    "/src/mandarine/hello_world",
+    "/src/resources",
+    "/src/resources/templates",
+    "/src/resources/static",
+  ],
+  files: {
+    "/src/resources/properties.json": Structure.DefaultConfig,
+    "/src/mandarine/app.ts": Structure.DefaultAppFile,
+    "/src/mandarine/hello_world/helloWorld.ts":
+      Structure.DefaultHelloWorldEndpoint,
+    "/tsconfig.json": Structure.DefaultTsConfig,
+  },
+};

--- a/version.ts
+++ b/version.ts
@@ -1,1 +1,3 @@
-export const cliVersion = "1.1.0";
+// Copyright 2020-2020 The Mandarine.TS Framework authors. All rights reserved. MIT license.
+
+export const cliVersion = "1.1.1";


### PR DESCRIPTION
these are the changes I made:

- exports from the [`defaultFiles.ts`](https://github.com/mandarineorg/mandarine-cli/blob/master/defaults/defaultFiles.ts) file were transformed into a single enum
- copyright message on all files
- the [`mandarine-project-structure.ts`](https://github.com/mandarineorg/mandarinets/blob/master/mandarine-project-structure.ts) file has been modified so that the templates are in a single enum and is now local
- when the template is generated it no longer includes the `main` folder
- the template path when started is `/`
- readme information updated

I have already tried everything and it works well but it needs more tests